### PR TITLE
Postgres locker - 1 of 2

### DIFF
--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -43,6 +43,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-postgresql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <scope>test</scope>

--- a/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLock.java
+++ b/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLock.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.locker.postgresql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.killbill.commons.locker.GlobalLock;
+
+public class PostgreSQLGlobalLock implements GlobalLock {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLGlobalLock.class);
+
+    private final PostgreSQLGlobalLockDao lockDao = new PostgreSQLGlobalLockDao();
+
+    private final Connection connection;
+    private final String lockName;
+
+    public PostgreSQLGlobalLock(final Connection connection, final String lockName) {
+        this.connection = connection;
+        this.lockName = lockName;
+    }
+
+    @Override
+    public void release() {
+        try {
+            lockDao.releaseLock(connection, lockName);
+        } catch (SQLException e) {
+            logger.warn("Unable to release lock for " + lockName, e);
+        } finally {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                logger.warn("Unable to close connection", e);
+            }
+        }
+    }
+}

--- a/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLockDao.java
+++ b/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLockDao.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.locker.postgresql;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+// Note: the lock is connection specific (closing the connection releases the lock)
+public class PostgreSQLGlobalLockDao {
+
+    public boolean lock(final Connection connection, final String lockName) throws SQLException {
+        final String sql = String.format("SELECT pg_try_advisory_lock(%s);", lockName);
+        return executeLockQuery(connection, sql);
+    }
+
+    public boolean releaseLock(final Connection connection, final String lockName) throws SQLException {
+        final String sql = String.format("SELECT pg_advisory_unlock(%s);", lockName);
+        return executeLockQuery(connection, sql);
+    }
+
+    public boolean isLockFree(final Connection connection, final String lockName) throws SQLException {
+        final String sql = String.format("SELECT CASE WHEN pg_try_advisory_lock(%s) THEN pg_advisory_unlock(%s) ELSE FALSE END;", lockName, lockName);
+        return executeLockQuery(connection, sql);
+    }
+
+    private boolean executeLockQuery(final Connection connection, final String query) throws SQLException {
+        Statement statement = null;
+        try {
+            statement = connection.createStatement();
+            final ResultSet rs = statement.executeQuery(query);
+            return rs.next() && (rs.getBoolean(1));
+        } finally {
+            if (statement != null) {
+                statement.close();
+            }
+        }
+    }
+}

--- a/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLocker.java
+++ b/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLocker.java
@@ -35,7 +35,7 @@ import org.killbill.commons.locker.LockFailedException;
 public class PostgreSQLGlobalLocker implements GlobalLocker {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgreSQLGlobalLocker.class);
-    private static final long DEFAULT_TIMEOUT_SECONDS = 10L;
+    private static final long DEFAULT_TIMEOUT_SECONDS = 1L;
 
     private final PostgreSQLGlobalLockDao lockDao = new PostgreSQLGlobalLockDao();
 
@@ -60,6 +60,12 @@ public class PostgreSQLGlobalLocker implements GlobalLocker {
             final GlobalLock lock = lock(lockName);
             if (lock != null) {
                 return lock;
+            } else if (tries_left > 0) {
+                try {
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(timeout));
+                } catch (InterruptedException e) {
+
+                }
             }
         }
 
@@ -111,7 +117,7 @@ public class PostgreSQLGlobalLocker implements GlobalLocker {
                 }
             }
         }
-        throw new LockFailedException();
+        return null;
     }
 
     private String getLockName(final String service, final String lockKey) {

--- a/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLocker.java
+++ b/locker/src/main/java/org/killbill/commons/locker/postgresql/PostgreSQLGlobalLocker.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.locker.postgresql;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.killbill.commons.locker.GlobalLock;
+import org.killbill.commons.locker.GlobalLocker;
+import org.killbill.commons.locker.LockFailedException;
+
+public class PostgreSQLGlobalLocker implements GlobalLocker {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLGlobalLocker.class);
+    private static final long DEFAULT_TIMEOUT_SECONDS = 10L;
+
+    private final PostgreSQLGlobalLockDao lockDao = new PostgreSQLGlobalLockDao();
+
+    private final DataSource dataSource;
+    private final long timeout;
+
+    public PostgreSQLGlobalLocker(final DataSource dataSource) {
+        this(dataSource, DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public PostgreSQLGlobalLocker(final DataSource dataSource, final long timeout, final TimeUnit timeUnit) {
+        this.dataSource = dataSource;
+        this.timeout = TimeUnit.SECONDS.convert(timeout, timeUnit);
+    }
+
+    @Override
+    public GlobalLock lockWithNumberOfTries(final String service, final String lockKey, final int retry) throws LockFailedException {
+        final String lockName = getLockName(service, lockKey);
+
+        int tries_left = retry;
+        while (tries_left-- > 0) {
+            final GlobalLock lock = lock(lockName);
+            if (lock != null) {
+                return lock;
+            }
+        }
+
+        logger.warn(String.format("Failed to acquire lock %s for service %s after %d retries", lockKey, service, retry));
+        throw new LockFailedException();
+    }
+
+    @Override
+    public boolean isFree(final String service, final String lockKey) {
+        final String lockName = getLockName(service, lockKey);
+
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            return lockDao.isLockFree(connection, lockName);
+        } catch (SQLException e) {
+            logger.warn("Unable to check if lock is free", e);
+            return false;
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    logger.warn("Unable to close connection", e);
+                }
+            }
+        }
+    }
+
+    private GlobalLock lock(final String lockName) throws LockFailedException {
+        Connection connection = null;
+        boolean obtained = false;
+        try {
+            connection = dataSource.getConnection();
+            obtained = lockDao.lock(connection, lockName);
+            if (obtained) {
+                return new PostgreSQLGlobalLock(connection, lockName);
+            }
+        } catch (SQLException e) {
+            logger.warn("Unable to obtain lock for " + lockName, e);
+        } finally {
+            if (!obtained) {
+                if (connection != null) {
+                    try {
+                        connection.close();
+                    } catch (SQLException e) {
+                        logger.warn("Unable to close connection", e);
+                    }
+                }
+            }
+        }
+        throw new LockFailedException();
+    }
+
+    private String getLockName(final String service, final String lockKey) {
+        String lockName = service + "-" + lockKey;
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+            byte[] bytes = messageDigest.digest(lockName.getBytes());
+            return String.valueOf(ByteBuffer.wrap(bytes).getLong());
+       } catch (NoSuchAlgorithmException e) {
+           logger.warn("Unable to allocate MessageDigest", e);
+           return String.valueOf(lockName.hashCode());
+       }
+    }
+}

--- a/locker/src/test/java/org/killbill/commons/locker/postgresql/TestPostgreSQLGlobalLocker.java
+++ b/locker/src/test/java/org/killbill/commons/locker/postgresql/TestPostgreSQLGlobalLocker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.locker.postgresql;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.killbill.commons.embeddeddb.postgresql.PostgreSQLStandaloneDB;
+import org.killbill.commons.locker.GlobalLock;
+import org.killbill.commons.locker.GlobalLocker;
+import org.killbill.commons.locker.LockFailedException;
+
+public class TestPostgreSQLGlobalLocker {
+
+    private PostgreSQLStandaloneDB embeddedDB;
+
+    @BeforeClass(groups = "postgresql")
+    public void setUp() throws Exception {
+
+        final String databaseName = System.getProperty("org.killbill.billing.dbi.test.localDb.database", "postgres");
+        final String username = System.getProperty("org.killbill.billing.dbi.test.localDb.username", "postgres");
+        final String password = System.getProperty("org.killbill.billing.dbi.test.localDb.password", "postgres");
+
+        embeddedDB = new PostgreSQLStandaloneDB(databaseName, username, password);
+        embeddedDB.initialize();
+        embeddedDB.start();
+
+    }
+
+    @AfterClass(groups = "postgresql")
+    public void tearDown() throws Exception {
+        embeddedDB.stop();
+    }
+
+    @Test(groups = "postgresql")
+    public void testSimpleLocking() throws IOException, LockFailedException {
+        final String serviceLock = "MY_AWESOME_LOCK";
+        final String lockName = UUID.randomUUID().toString();
+
+        final GlobalLocker locker = new PostgreSQLGlobalLocker(embeddedDB.getDataSource());
+        final GlobalLock lock = locker.lockWithNumberOfTries(serviceLock, lockName, 3);
+        Assert.assertFalse(locker.isFree(serviceLock, lockName));
+
+        boolean gotException = false;
+        try {
+            locker.lockWithNumberOfTries(serviceLock, lockName, 1);
+        } catch (LockFailedException e) {
+            gotException = true;
+        }
+        Assert.assertTrue(gotException);
+
+        lock.release();
+        Assert.assertTrue(locker.isFree(serviceLock, lockName));
+    }
+}


### PR DESCRIPTION
@dconcha @mhmartinez 

Implementation of a concurrency locker for Postgres.  This is based on the existing MySQL locker, with adaptations as necessary to use 'advisory locks' as the lock mechanism.  The acceptance criteria for this work is the unit test.
